### PR TITLE
feat: Phase 10 - Database Provider Adapter Layer

### DIFF
--- a/betterbase_blueprint_v3.md
+++ b/betterbase_blueprint_v3.md
@@ -1,0 +1,575 @@
+# BetterBase: Blueprint v3.0 — New Feature Phases (10–15)
+
+> **Status:** Phases 1–8.1 complete. Phase 9 (Dashboard UI) in progress separately.
+> **This document covers:** Phases 10–15 — the 6 new feature layers being added to BetterBase as open-source infrastructure.
+> **Philosophy:** Zero vendor lock-in. User owns everything. AI-native. Docker-less. Open source first, managed cloud later.
+
+---
+
+## Project Identity (Include in every prompt)
+
+| Field | Value |
+|---|---|
+| **Project** | BetterBase |
+| **Type** | AI-Native Backend-as-a-Service Framework |
+| **Positioning** | Open-source Supabase alternative — better DX, zero lock-in |
+| **Stack** | Bun + TypeScript + Hono + Drizzle ORM + BetterAuth |
+| **Monorepo** | Turborepo (`apps/cli`, `apps/dashboard`, `packages/core`, `packages/client`, `packages/shared`) |
+| **CLI Command** | `bb` |
+| **Local DB** | SQLite (dev) via `bun:sqlite` |
+| **Production DB** | Provider-agnostic (see Phase 10) |
+| **Auth** | BetterAuth — user owns the auth tables |
+| **AI Context File** | `.betterbase-context.json` — auto-generated machine-readable manifest |
+| **Development Model** | Solo dev, 80% AI code generation, 20% human review |
+
+---
+
+## What Has Changed From v2.0 That These Phases Affect
+
+Before reading the phases, understand the parts of the existing codebase that will be **modified** (not just extended) by this work:
+
+### `betterbase.config.ts` (Template)
+Currently holds basic project config. Phases 10 and 14 both add new top-level config blocks:
+- `provider` block (Phase 10) — database adapter selection
+- `storage` block (Phase 14) — S3-compatible credentials and bucket config
+
+### `bb init` Interactive Prompts (apps/cli)
+Currently asks: project name, local or production, database URL.
+Phases 10 and 14 add new prompts:
+- "Which database provider?" (Neon / Turso / PlanetScale / Supabase DB / Raw Postgres / Managed — coming soon)
+- "Set up S3-compatible storage now?" (optional, skippable)
+
+### `drizzle.config.ts` (Template)
+Currently likely hardcoded for SQLite → Postgres switching.
+Phase 10 makes this **dynamically generated** based on provider selection.
+
+### Migration System (`bb migrate`)
+Currently handles schema diffs.
+Phase 11 (RLS) adds a policy migration hook — RLS policy files must be applied alongside schema migrations.
+
+### `.betterbase-context.json`
+Currently contains tables, columns, routes, and AI instructions.
+Phases 11 and 12 both add new fields:
+- `rls_policies` — what policies exist per table (Phase 11)
+- `graphql_schema` — the auto-generated GraphQL SDL (Phase 12)
+
+### Auth Package (BetterAuth integration)
+Currently generates auth tables and middleware.
+Phase 11 (RLS) requires the auth user ID (`auth.uid()` equivalent) to be accessible at the Postgres session level so policies can reference it. This may require a small addition to the auth middleware.
+
+---
+
+## Phase 10: Database Provider Adapter Layer
+
+### What you're building
+A provider-agnostic database connection and configuration system. Instead of BetterBase assuming Postgres or SQLite, the user picks their provider and BetterBase generates the correct Drizzle config, connection string format, and migration commands for that provider.
+
+### Why this matters
+Zero vendor lock-in from day one. A developer using Turso should get the same BetterBase experience as one using Neon. And when BetterBase launches its own managed cloud later, it slots in as just another provider option — no API changes for the user.
+
+### Providers supported in v1
+| Provider | Type | Notes |
+|---|---|---|
+| Neon | Serverless Postgres | Connection pooling via `@neondatabase/serverless` |
+| Turso | LibSQL / SQLite edge | Uses `@libsql/client` |
+| PlanetScale | MySQL-compatible | Uses `@planetscale/database` |
+| Supabase (DB only) | Postgres | Direct connection, no Supabase SDK needed |
+| Raw Postgres | Standard Postgres | Uses `postgres` or `pg` driver |
+| Managed (BetterBase) | Coming soon | Placeholder, disabled in CLI for now |
+
+### How it works
+
+**During `bb init`:**
+```
+? What database provider would you like to use?
+  ❯ Neon (Serverless Postgres)
+    Turso (SQLite Edge)
+    PlanetScale (MySQL-compatible)
+    Supabase (Postgres DB only)
+    Raw Postgres
+    Managed by BetterBase (coming soon)
+```
+
+This generates a `betterbase.config.ts` with a `provider` block:
+
+```typescript
+// betterbase.config.ts
+export default defineConfig({
+  project: {
+    name: "my-app",
+  },
+  provider: {
+    type: "neon",
+    connectionString: process.env.DATABASE_URL,
+  },
+  // storage block added in Phase 14
+})
+```
+
+And generates the correct `drizzle.config.ts` for that provider automatically.
+
+**Provider adapter in `packages/core`:**
+Each provider gets its own adapter file:
+```
+packages/core/src/providers/
+  neon.ts
+  turso.ts
+  planetscale.ts
+  supabase.ts
+  postgres.ts
+  index.ts  ← resolves adapter from config
+```
+
+The adapter interface:
+```typescript
+interface ProviderAdapter {
+  connect(config: ProviderConfig): Promise<DatabaseConnection>
+  getMigrationsDriver(): DrizzleMigrationDriver
+  supportsRLS(): boolean       // false for Turso/PlanetScale
+  supportsGraphQL(): boolean   // true for all Postgres-based
+}
+```
+
+### Notes
+- `supportsRLS()` and `supportsGraphQL()` are used by Phases 11 and 12 to warn the user if their provider doesn't support those features
+- The `Managed by BetterBase` option is visible in the CLI but marked as `[coming soon]` and exits with a friendly message
+- Migration commands stay the same (`bb migrate`) — the adapter handles the driver difference internally
+
+---
+
+## Phase 11: Row-Level Security (RLS)
+
+### What you're building
+A Postgres RLS policy management system that integrates with BetterAuth. Users define policies in their codebase, and BetterBase applies them as part of migrations.
+
+### Why this matters
+RLS is the missing security layer between "auth works" and "data is actually protected at the database level." Without it, a leaked API key can read any row. With it, even direct DB access is scoped to the authenticated user.
+
+### Prerequisite
+Provider must support RLS (`supportsRLS() === true`). If the user is on Turso or PlanetScale, `bb rls` commands will warn and exit.
+
+### How it works
+
+**New CLI command:**
+```bash
+bb rls create <table>
+# Example:
+bb rls create posts
+```
+
+This generates a policy file:
+```
+src/db/policies/
+  posts.policy.ts
+```
+
+**Policy file format:**
+```typescript
+// src/db/policies/posts.policy.ts
+import { definePolicy } from "@betterbase/core/rls"
+
+export default definePolicy("posts", {
+  select: "auth.uid() = user_id",
+  insert: "auth.uid() = user_id",
+  update: "auth.uid() = user_id",
+  delete: "auth.uid() = user_id",
+})
+```
+
+**Auth integration:**
+The auth middleware is extended to set the Postgres session variable on each request:
+```typescript
+// Set in request middleware, before DB queries
+await db.execute(sql`SET LOCAL app.current_user_id = ${userId}`)
+```
+
+And in Postgres, `auth.uid()` is a function that reads this:
+```sql
+CREATE OR REPLACE FUNCTION auth.uid()
+RETURNS uuid AS $$
+  SELECT current_setting('app.current_user_id', true)::uuid
+$$ LANGUAGE sql;
+```
+
+**Migration integration:**
+`bb migrate` now also picks up policy files and applies them:
+```
+bb migrate
+→ Applying schema changes...
+→ Applying RLS policies: posts, comments (2 policies)
+→ Done
+```
+
+**Context file update:**
+`.betterbase-context.json` gains a `rls_policies` field:
+```json
+{
+  "rls_policies": {
+    "posts": {
+      "select": "auth.uid() = user_id",
+      "insert": "auth.uid() = user_id"
+    }
+  }
+}
+```
+
+### Notes
+- RLS is opt-in per table. Tables without a policy file are unprotected (by design — developer's choice)
+- `bb rls list` shows all active policies
+- `bb rls disable <table>` drops the policy without deleting the file
+
+---
+
+## Phase 12: GraphQL API
+
+### What you're building
+An auto-generated GraphQL API mounted at `/api/graphql`, derived entirely from the Drizzle schema. Zero manual schema writing.
+
+### Why this matters
+Some teams prefer GraphQL over REST. BetterBase should support both without the developer writing a second API layer.
+
+### How it works
+
+**Auto-generation:**
+When the user runs `bb generate graphql` (or it runs automatically during `bb dev`), BetterBase scans `src/db/schema.ts` and generates a full GraphQL schema and resolvers.
+
+**Library:**
+Uses `Pothos` (schema builder) with a Drizzle plugin. This gives type-safe GraphQL resolvers that are derived from Drizzle types — no type drift.
+
+**Mounted in Hono:**
+```typescript
+// src/routes/graphql.ts (auto-generated)
+import { createYoga } from "graphql-yoga"
+import { schema } from "../lib/graphql/schema"
+
+export const graphqlRoute = new Hono()
+graphqlRoute.use("/api/graphql", createYoga({ schema }))
+```
+
+**What gets generated for each table:**
+- Query: `users`, `usersBy(id)`, `usersList(filter, limit, offset)`
+- Mutation: `createUser`, `updateUser`, `deleteUser`
+- Subscription: `onUserChange` (if realtime is enabled)
+
+**Auth protection:**
+GraphQL routes respect the existing `requireAuth()` middleware from Phase 4. Resolvers can call `getUser()` for per-resolver auth checks.
+
+**Context file update:**
+```json
+{
+  "graphql_schema": "type User { id: ID! email: String! ... }  type Query { users: [User!]! ... }"
+}
+```
+
+**New CLI command:**
+```bash
+bb generate graphql     # regenerate the schema
+bb graphql playground   # open GraphQL Playground in browser
+```
+
+### Notes
+- The GraphQL schema is always in sync with the Drizzle schema. Any `bb migrate` run also triggers a GraphQL schema regeneration
+- If the provider does not support Postgres (`supportsGraphQL() === false`), a warning is shown but generation still works — only subscriptions are skipped
+- The playground is disabled in production by default
+
+---
+
+## Phase 13: Webhooks
+
+### What you're building
+A database event webhook system. When rows are inserted, updated, or deleted in a table, BetterBase fires an HTTP POST to a user-defined URL with a signed payload.
+
+### Why this matters
+Webhooks are the connective tissue between a backend and the rest of the world — Slack notifications, email triggers, third-party sync, audit logs. Without them, developers have to poll or build their own event system.
+
+### How it works
+
+**User defines webhooks in config or via CLI:**
+```bash
+bb webhook create
+# Prompts:
+# → Table: posts
+# → Events: INSERT, UPDATE
+# → Target URL: https://my-app.com/webhooks/posts
+```
+
+This generates an entry in `betterbase.config.ts`:
+```typescript
+webhooks: [
+  {
+    table: "posts",
+    events: ["INSERT", "UPDATE"],
+    url: process.env.WEBHOOK_POSTS_URL,
+    secret: process.env.WEBHOOK_SECRET,
+  }
+]
+```
+
+**Delivery mechanism:**
+Built on top of the existing realtime layer. When a WebSocket event fires (Phase 6), the webhook dispatcher intercepts it and makes an HTTP POST:
+
+```typescript
+// packages/core/src/webhooks/dispatcher.ts
+export async function dispatch(event: DBEvent, webhook: WebhookConfig) {
+  const payload = {
+    table: event.table,
+    type: event.type,           // INSERT | UPDATE | DELETE
+    record: event.new,
+    old_record: event.old,
+    timestamp: new Date().toISOString(),
+  }
+  const signature = signPayload(payload, webhook.secret)
+  await fetch(webhook.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-BetterBase-Signature": signature,
+    },
+    body: JSON.stringify(payload),
+  })
+}
+```
+
+**Signature verification (for webhook receivers):**
+```typescript
+import { verifyWebhook } from "@betterbase/client"
+
+const isValid = verifyWebhook(payload, signature, process.env.WEBHOOK_SECRET)
+```
+
+**Retry logic:**
+Failed deliveries retry 3 times with exponential backoff (1s, 5s, 30s). Failures are logged to the observability layer.
+
+**CLI commands:**
+```bash
+bb webhook create        # create a new webhook
+bb webhook list          # list all configured webhooks
+bb webhook test <id>     # send a test payload to the URL
+bb webhook logs <id>     # see delivery history
+```
+
+### Notes
+- Webhooks require the realtime WebSocket layer (Phase 6) to be active
+- In production, the `url` should always reference an environment variable, never a hardcoded string
+- `bb webhook test` is critical for local development — sends a synthetic payload to the target URL
+
+---
+
+## Phase 14: S3-Compatible Storage
+
+### What you're building
+A storage interaction layer that wraps any S3-compatible service (AWS S3, Cloudflare R2, Backblaze B2, MinIO). The user brings their own credentials. BetterBase provides the clean API. In the future, BetterBase will offer its own managed storage — the API will not change.
+
+### Why this matters
+File storage is one of the top missing features compared to Supabase. Every real app needs it. The BYOK (Bring Your Own Keys) model means the user has zero vendor lock-in and full cost control.
+
+### Setup
+
+**During `bb init` or via `bb storage init`:**
+```
+? Set up storage now?
+  ❯ Yes — I have AWS/S3-compatible credentials
+    Skip for now
+    Use managed storage (coming soon)
+```
+
+This adds to `.env`:
+```
+STORAGE_PROVIDER=s3
+STORAGE_REGION=us-east-1
+STORAGE_BUCKET=my-app-uploads
+STORAGE_ACCESS_KEY=xxx
+STORAGE_SECRET_KEY=xxx
+STORAGE_ENDPOINT=          # optional, for R2/Backblaze/MinIO
+```
+
+And adds to `betterbase.config.ts`:
+```typescript
+storage: {
+  provider: "s3",           // "s3" | "r2" | "backblaze" | "minio" | "managed"
+  bucket: process.env.STORAGE_BUCKET,
+  region: process.env.STORAGE_REGION,
+  endpoint: process.env.STORAGE_ENDPOINT,  // optional
+}
+```
+
+### The storage API (via `@betterbase/client`)
+
+```typescript
+const bb = createClient({ url, key })
+
+// Upload
+const { data, error } = await bb.storage
+  .from("avatars")
+  .upload("user-123.jpg", file, { contentType: "image/jpeg" })
+
+// Download
+const { data } = await bb.storage
+  .from("avatars")
+  .download("user-123.jpg")
+
+// Get public URL
+const { publicUrl } = bb.storage
+  .from("avatars")
+  .getPublicUrl("user-123.jpg")
+
+// Generate signed URL (private files)
+const { signedUrl } = await bb.storage
+  .from("documents")
+  .createSignedUrl("contract.pdf", { expiresIn: 3600 })
+
+// Delete
+await bb.storage.from("avatars").remove(["user-123.jpg"])
+```
+
+### Server-side in Hono routes
+
+```typescript
+import { storage } from "@betterbase/core/storage"
+
+app.post("/upload", requireAuth(), async (c) => {
+  const file = await c.req.formData()
+  const result = await storage.upload("avatars", file.get("file"))
+  return c.json({ url: result.publicUrl })
+})
+```
+
+### Bucket types
+- **Public bucket** — files are publicly accessible via URL
+- **Private bucket** — files require signed URLs (default)
+
+### CLI commands
+```bash
+bb storage init           # configure storage credentials
+bb storage buckets list   # list all buckets
+bb storage upload <file>  # upload a file (dev utility)
+```
+
+### Notes
+- For Cloudflare R2, set `endpoint` to your R2 endpoint URL and `region` to `auto`
+- The `managed` provider option is a placeholder in the CLI — it shows as available but exits with "Coming soon — managed storage launching Q2 2025"
+- Credentials must never be committed. `bb storage init` automatically adds storage vars to `.gitignore`
+
+---
+
+## Phase 15: Edge Functions
+
+### What you're building
+A system for writing, bundling, and deploying standalone serverless functions from within a BetterBase project. Functions are written in TypeScript with Hono, bundled by Bun, and deployed to Cloudflare Workers or Vercel Edge.
+
+### Why this matters
+Some logic doesn't belong in the main API — image processing, background jobs, AI inference, webhooks receivers. Edge functions let developers deploy isolated pieces of logic without leaving the BetterBase ecosystem.
+
+### How it works
+
+**Create a function:**
+```bash
+bb function create send-email
+```
+
+This scaffolds:
+```
+src/functions/
+  send-email/
+    index.ts
+    config.ts
+```
+
+**Function template:**
+```typescript
+// src/functions/send-email/index.ts
+import { Hono } from "hono"
+
+const app = new Hono()
+
+app.post("/", async (c) => {
+  const { to, subject, body } = await c.req.json()
+  // your logic here
+  return c.json({ success: true })
+})
+
+export default app
+```
+
+**Function config:**
+```typescript
+// src/functions/send-email/config.ts
+export default {
+  name: "send-email",
+  runtime: "cloudflare-workers",  // "cloudflare-workers" | "vercel-edge"
+  env: ["RESEND_API_KEY"],
+}
+```
+
+**Bundle:**
+```bash
+bb function build send-email
+# Uses Bun.build to bundle to a single file
+# Output: .betterbase/functions/send-email.js
+```
+
+**Deploy:**
+```bash
+bb function deploy send-email
+# Deploys to Cloudflare Workers or Vercel Edge based on config.runtime
+```
+
+**Cloudflare deployment** uses `wrangler` CLI under the hood.
+**Vercel deployment** uses `vercel` CLI under the hood.
+Both are installed as dev dependencies when the user creates their first function.
+
+**Access BetterBase core packages from a function:**
+```typescript
+import { createClient } from "@betterbase/client"
+
+const bb = createClient({
+  url: process.env.BETTERBASE_URL,
+  key: process.env.BETTERBASE_KEY,
+})
+```
+
+Functions access the database through the `@betterbase/client` SDK — they do not import `packages/core` directly (edge runtimes have limitations).
+
+**CLI commands:**
+```bash
+bb function create <name>      # scaffold a new function
+bb function build <name>       # bundle for edge deployment
+bb function deploy <name>      # deploy to configured runtime
+bb function list               # list all functions in the project
+bb function dev <name>         # run function locally with hot reload
+bb function logs <name>        # tail logs (Cloudflare or Vercel)
+```
+
+### Notes
+- Functions are isolated from the main Hono API. They are separate deployments
+- `bb function dev` runs the function locally via Bun on a separate port (default: 3001+)
+- Environment variables for functions are defined in `config.ts` and must exist in `.env` locally and in the target platform's dashboard for production
+- Cloudflare Workers and Vercel Edge are the only supported runtimes in v1. AWS Lambda and Deno Deploy are candidates for v2
+
+---
+
+## Feature Compatibility Matrix
+
+| Feature | Neon | Turso | PlanetScale | Supabase DB | Raw Postgres |
+|---|---|---|---|---|---|
+| DB Provider Adapter | ✅ | ✅ | ✅ | ✅ | ✅ |
+| RLS (Phase 11) | ✅ | ❌ | ❌ | ✅ | ✅ |
+| GraphQL (Phase 12) | ✅ | ⚠️ partial | ⚠️ partial | ✅ | ✅ |
+| Webhooks (Phase 13) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Storage (Phase 14) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Edge Functions (Phase 15) | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+> ⚠️ partial = works for queries/mutations, subscriptions skipped
+
+---
+
+## Recommended Build Order
+
+```
+Phase 10 (Provider Adapter) → FIRST. Everything else references the provider.
+Phase 14 (Storage)          → Can be built in parallel with Phase 11.
+Phase 11 (RLS)              → Depends on Phase 10 (needs provider.supportsRLS()).
+Phase 12 (GraphQL)          → Depends on Phase 10 + schema being stable.
+Phase 13 (Webhooks)         → Depends on Phase 6 (realtime) already being done. ✅
+Phase 15 (Edge Functions)   → Independent. Can be built any time after Phase 8.
+```

--- a/bun.lock
+++ b/bun.lock
@@ -78,8 +78,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@betterbase/shared": "workspace:*",
+        "@libsql/client": "latest",
+        "@neondatabase/serverless": "latest",
+        "@planetscale/database": "latest",
         "drizzle-orm": "^0.44.5",
         "hono": "^4.6.10",
+        "postgres": "latest",
         "zod": "^3.23.8",
       },
       "devDependencies": {
@@ -266,6 +270,8 @@
 
     "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
+    "@neondatabase/serverless": ["@neondatabase/serverless@1.0.2", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw=="],
+
     "@next/env": ["@next/env@15.5.12", "", {}, "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg=="],
@@ -287,6 +293,8 @@
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "@planetscale/database": ["@planetscale/database@1.19.0", "", {}, "sha512-Tv4jcFUFAFjOWrGSio49H6R2ijALv0ZzVBfJKIdm+kl9X046Fh4LLawrF9OMsglVbK6ukqMJsUCeucGAFTBcMA=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
@@ -405,6 +413,8 @@
     "@types/mute-stream": ["@types/mute-stream@0.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow=="],
 
     "@types/node": ["@types/node@22.19.11", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w=="],
+
+    "@types/pg": ["@types/pg@8.16.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -590,11 +600,27 @@
 
     "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
 
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
 
@@ -700,6 +726,8 @@
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -730,6 +758,8 @@
 
     "@types/mute-stream/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
+    "@types/pg/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
     "@types/ws/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -747,6 +777,8 @@
     "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "@types/mute-stream/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { z } from 'zod';
 import * as logger from '../utils/logger';
 import * as prompts from '../utils/prompts';
+import { promptForProvider, generateEnvContent } from '../utils/provider-prompts';
+import { generateDrizzleConfig } from '@betterbase/core/config';
 
 const projectNameSchema = z
   .string()
@@ -14,9 +16,9 @@ const initOptionsSchema = z.object({
   projectName: projectNameSchema.optional(),
 });
 
-export type ProviderType = 'local' | 'neon' | 'turso' | 'planetscale' | 'supabase' | 'postgres';
+import type { ProviderType } from '@betterbase/shared';
 
-const providerTypeSchema = z.enum(['local', 'neon', 'turso', 'planetscale', 'supabase', 'postgres']);
+const providerTypeSchema = z.enum(['neon', 'turso', 'planetscale', 'supabase', 'postgres', 'managed']);
 
 export type InitCommandOptions = z.infer<typeof initOptionsSchema>;
 
@@ -38,18 +40,18 @@ interface StorageCredentials {
 
 function getDatabaseLabel(provider: ProviderType): string {
   const labels: Record<ProviderType, string> = {
-    local: 'Local SQLite (local.db)',
     neon: 'Neon (serverless Postgres)',
     turso: 'Turso (edge SQLite)',
     planetscale: 'PlanetScale (MySQL-compatible)',
     supabase: 'Supabase (Postgres)',
     postgres: 'Raw Postgres',
+    managed: 'Managed by BetterBase (coming soon)',
   };
   return labels[provider];
 }
 
 function getAuthDialect(provider: ProviderType): 'sqlite' | 'pg' | 'mysql' {
-  if (provider === 'local' || provider === 'turso') {
+  if (provider === 'turso') {
     return 'sqlite';
   }
   if (provider === 'planetscale') {
@@ -97,11 +99,15 @@ function buildPackageJson(
     zod: '^4.3.6',
   };
 
+  if (provider === 'neon') {
+    dependencies['@neondatabase/serverless'] = '^1.0.0';
+  }
+
   if (provider === 'turso') {
     dependencies['@libsql/client'] = '^0.14.0';
   }
 
-  if (provider === 'neon' || provider === 'postgres' || provider === 'supabase') {
+  if (provider === 'postgres' || provider === 'supabase') {
     dependencies.pg = '^8.13.1';
   }
 
@@ -136,61 +142,21 @@ function buildPackageJson(
 }
 
 function buildDrizzleConfig(provider: ProviderType): string {
-  const configs: Record<ProviderType, string> = {
-    local: `import { defineConfig } from "drizzle-kit";
-export default defineConfig({
-  schema: "./src/db/schema.ts",
-  dialect: "sqlite",
-  dbCredentials: { url: "./local.db" },
-});`,
-    neon: `import { defineConfig } from "drizzle-kit";
-export default defineConfig({
-  schema: "./src/db/schema.ts",
-  dialect: "postgresql",
-  driver: "neon-serverless",
-  dbCredentials: { connectionString: process.env.DATABASE_URL },
-});`,
-    turso: `import { defineConfig } from "drizzle-kit";
-export default defineConfig({
-  schema: "./src/db/schema.ts",
-  dialect: "sqlite",
-  driver: "turso",
-  dbCredentials: { url: process.env.TURSO_URL, authToken: process.env.TURSO_AUTH_TOKEN },
-});`,
-    planetscale: `import { defineConfig } from "drizzle-kit";
-export default defineConfig({
-  schema: "./src/db/schema.ts",
-  dialect: "mysql",
-  driver: "planetscale",
-  dbCredentials: { connectionString: process.env.DATABASE_URL },
-});`,
-    supabase: `import { defineConfig } from "drizzle-kit";
-export default defineConfig({
-  schema: "./src/db/schema.ts",
-  dialect: "postgresql",
-  driver: "pg",
-  dbCredentials: { connectionString: process.env.DATABASE_URL },
-});`,
-    postgres: `import { defineConfig } from "drizzle-kit";
-export default defineConfig({
-  schema: "./src/db/schema.ts",
-  dialect: "postgresql",
-  driver: "pg",
-  dbCredentials: { connectionString: process.env.DATABASE_URL },
-});`,
-  };
-  return configs[provider];
+  // Use the generateDrizzleConfig from @betterbase/core
+  return generateDrizzleConfig(provider);
 }
 
 function buildBetterbaseConfig(projectName: string, provider: ProviderType): string {
   let providerBlock = `type: "${provider}",`;
 
-  if (provider === 'local') {
-    // No connection string for local
-  } else if (provider === 'turso') {
+  if (provider === 'turso') {
     providerBlock += `
     url: process.env.TURSO_URL,
     authToken: process.env.TURSO_AUTH_TOKEN,`;
+  } else if (provider === 'managed') {
+    // Managed provider - no connection string needed for now
+    providerBlock += `
+    connectionString: process.env.DATABASE_URL,`;
   } else {
     providerBlock += `
     connectionString: process.env.DATABASE_URL,`;
@@ -746,24 +712,11 @@ async function writeProjectFiles(
   await mkdir(path.join(projectPath, 'src/lib'), { recursive: true });
 
   // Build .env content based on provider and credentials
-  let envContent = '';
-  if (provider === 'local') {
-    envContent = `NODE_ENV=development
-PORT=3000
-DB_PATH=local.db
-`;
-  } else if (provider === 'turso') {
-    envContent = `NODE_ENV=development
-PORT=3000
-TURSO_URL=${dbCredentials.TURSO_URL || ''}
-TURSO_AUTH_TOKEN=${dbCredentials.TURSO_AUTH_TOKEN || ''}
-`;
-  } else {
-    envContent = `NODE_ENV=development
-PORT=3000
-DATABASE_URL=${dbCredentials.DATABASE_URL || ''}
-`;
-  }
+  // Use the generateEnvContent from provider-prompts for better comments
+  let envContent = generateEnvContent(provider, dbCredentials as Record<string, string>);
+
+  // Add NODE_ENV and PORT to all configs
+  envContent = `NODE_ENV=development\nPORT=3000\n` + envContent;
 
   if (useAuth) {
     const authSecret = crypto.randomUUID().replace(/-/g, '').slice(0, 32);
@@ -796,7 +749,7 @@ PORT=3000
     envExampleContent += `TURSO_URL=
 TURSO_AUTH_TOKEN=
 `;
-  } else if (provider !== 'local') {
+  } else {
     envExampleContent += `DATABASE_URL=
 `;
   }
@@ -834,19 +787,18 @@ const envSchema = z.object({
   DB_PATH: z.string().min(1).default(DEFAULT_DB_PATH),
 });
 `;
-  if (provider !== 'local') {
-    if (provider === 'turso') {
-      envSchemaContent += `
+  // All providers except managed need DATABASE_URL or Turso-specific env vars
+  if (provider === 'turso') {
+    envSchemaContent += `
 envSchema = envSchema.extend({
   TURSO_URL: z.string().url(),
   TURSO_AUTH_TOKEN: z.string().min(1),
 });`;
-    } else {
-      envSchemaContent += `
+  } else if (provider !== 'managed') {
+    envSchemaContent += `
 envSchema = envSchema.extend({
   DATABASE_URL: z.string().url(),
 });`;
-    }
   }
 
   if (useAuth) {
@@ -1174,54 +1126,10 @@ export async function runInitCommand(rawOptions: InitCommandOptions): Promise<vo
   const projectName = projectNameSchema.parse(projectNameInput);
   const projectPath = path.resolve(process.cwd(), projectName);
 
-  // PROMPT 1 — Database Provider Selection
-  const selectedProvider = await prompts.select({
-    message: 'Which database provider?',
-    options: [
-      { value: 'local', label: 'Local SQLite (default, no config needed)' },
-      { value: 'neon', label: 'Neon (Serverless Postgres)' },
-      { value: 'turso', label: 'Turso (SQLite Edge)' },
-      { value: 'planetscale', label: 'PlanetScale (MySQL-compatible)' },
-      { value: 'supabase', label: 'Supabase (Postgres DB only)' },
-      { value: 'postgres', label: 'Raw Postgres' },
-      { value: 'managed', label: 'Managed by BetterBase (coming soon)' },
-    ],
-    default: 'local',
-  });
-
-  let provider: ProviderType = selectedProvider as ProviderType;
-
-  if (selectedProvider === 'managed') {
-    logger.warn('Managed database is coming soon. Defaulting to Local SQLite for now.');
-    provider = 'local';
-  }
-
-  // Collect credentials based on provider
-  const dbCredentials: DatabaseCredentials = {};
-
-  if (provider !== 'local') {
-    if (provider === 'turso') {
-      const tursoUrl = await prompts.text({
-        message: 'TURSO_URL (libsql connection string)',
-        initial: 'libsql://your-database.turso.io',
-      });
-      const tursoToken = await prompts.text({
-        message: 'TURSO_AUTH_TOKEN',
-        initial: '',
-      });
-      dbCredentials.TURSO_URL = tursoUrl;
-      dbCredentials.TURSO_AUTH_TOKEN = tursoToken;
-    } else {
-      const dbUrlLabel = provider === 'supabase' 
-        ? 'Direct connection string from Supabase project settings'
-        : 'DATABASE_URL';
-      const databaseUrl = await prompts.text({
-        message: dbUrlLabel,
-        initial: '',
-      });
-      dbCredentials.DATABASE_URL = databaseUrl;
-    }
-  }
+  // PROMPT 1 — Database Provider Selection using the new provider-prompts module
+  const { providerType, envVars } = await promptForProvider();
+  const provider: ProviderType = providerType;
+  const dbCredentials: DatabaseCredentials = envVars as DatabaseCredentials;
 
   // PROMPT 4 — BetterAuth Setup Option
   const authEnabled = await prompts.confirm({
@@ -1239,58 +1147,23 @@ export async function runInitCommand(rawOptions: InitCommandOptions): Promise<vo
     logger.info('You can run bb auth setup later to add authentication.');
   }
 
-  // PROMPT 5 — Storage Setup Option
-  storageEnabled = await prompts.confirm({
+  // PROMPT 5 — Storage Setup Option (placeholder - Phase 14)
+  const storageChoice = await prompts.select({
     message: 'Set up S3-compatible storage now?',
-    default: false,
+    options: [
+      { value: 'yes', label: 'Yes' },
+      { value: 'skip', label: 'Skip' },
+    ],
+    default: 'skip',
   });
 
-  if (storageEnabled) {
-    const selectedStorageProvider = await prompts.select({
-      message: 'Which storage provider?',
-      options: [
-        { value: 's3', label: 'AWS S3' },
-        { value: 'r2', label: 'Cloudflare R2' },
-        { value: 'backblaze', label: 'Backblaze B2' },
-        { value: 'minio', label: 'MinIO (self-hosted)' },
-      ],
-      default: 's3',
-    });
-
-    storageProvider = selectedStorageProvider as StorageProvider;
-
-    // Collect storage credentials based on provider
-    const accessKey = await prompts.text({
-      message: 'STORAGE_ACCESS_KEY',
-      initial: '',
-    });
-    const secretKey = await prompts.text({
-      message: 'STORAGE_SECRET_KEY',
-      initial: '',
-    });
-    const bucket = await prompts.text({
-      message: 'STORAGE_BUCKET',
-      initial: '',
-    });
-
-    storageCredentials.STORAGE_ACCESS_KEY = accessKey;
-    storageCredentials.STORAGE_SECRET_KEY = secretKey;
-    storageCredentials.STORAGE_BUCKET = bucket;
-
-    if (storageProvider === 's3') {
-      const region = await prompts.text({
-        message: 'STORAGE_REGION',
-        initial: 'us-east-1',
-      });
-      storageCredentials.STORAGE_REGION = region;
-    } else {
-      const endpoint = await prompts.text({
-        message: 'STORAGE_ENDPOINT (e.g., https://r2.cloudflarestorage.com)',
-        initial: '',
-      });
-      storageCredentials.STORAGE_ENDPOINT = endpoint;
-    }
+  if (storageChoice === 'yes') {
+    logger.info('Storage setup coming in Phase 14');
   }
+
+  // Storage is disabled for now - placeholder only
+  storageEnabled = false;
+  storageProvider = null;
 
   // PROMPT 6 — FINAL SUMMARY AND CONFIRMATION
   logger.info(`Creating project: ${projectName}`);

--- a/packages/cli/src/utils/provider-prompts.ts
+++ b/packages/cli/src/utils/provider-prompts.ts
@@ -1,0 +1,295 @@
+import inquirer from 'inquirer';
+import { z } from 'zod';
+import type { ProviderType } from '@betterbase/shared';
+
+/**
+ * Schema for validating provider type selection
+ */
+const providerSelectSchema = z.object({
+  value: z.string().min(1),
+  label: z.string().min(1),
+});
+
+/**
+ * Schema for provider selection prompt options
+ */
+const providerOptionsSchema = z.object({
+  message: z.string().min(1),
+  options: z.array(providerSelectSchema).min(1),
+  default: z.string().optional(),
+});
+
+/**
+ * Interface for provider prompt result
+ */
+export interface ProviderPromptResult {
+  /** The selected provider type */
+  providerType: ProviderType;
+  /** Map of environment variable names to their values */
+  envVars: Record<string, string>;
+}
+
+/**
+ * Interface for database credentials
+ */
+interface DatabaseCredentials {
+  DATABASE_URL?: string;
+  TURSO_URL?: string;
+  TURSO_AUTH_TOKEN?: string;
+}
+
+/**
+ * Gets the environment variable names required for a given provider type
+ * @param providerType - The database provider type
+ * @returns Array of required environment variable names
+ */
+function getRequiredEnvVars(providerType: ProviderType): string[] {
+  switch (providerType) {
+    case 'neon':
+    case 'planetscale':
+    case 'supabase':
+    case 'postgres':
+      return ['DATABASE_URL'];
+    case 'turso':
+      return ['TURSO_URL', 'TURSO_AUTH_TOKEN'];
+    case 'managed':
+      return ['DATABASE_URL'];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Gets the prompt message for the database URL based on provider type
+ * @param providerType - The database provider type
+ * @returns The prompt message string
+ */
+function getDbUrlPromptMessage(providerType: ProviderType): string {
+  switch (providerType) {
+    case 'supabase':
+      return 'DATABASE_URL (direct connection string from Supabase project settings)';
+    case 'neon':
+      return 'DATABASE_URL (get from https://console.neon.tech)';
+    case 'planetscale':
+      return 'DATABASE_URL (get from https://planetscale.com)';
+    case 'postgres':
+      return 'DATABASE_URL (PostgreSQL connection string)';
+    default:
+      return 'DATABASE_URL';
+  }
+}
+
+/**
+ * Prompts the user to select a database provider and collect credentials
+ * @returns Promise resolving to the provider type and environment variables
+ * 
+ * @example
+ * const result = await promptForProvider();
+ * // result: { providerType: 'neon', envVars: { DATABASE_URL: '...' } }
+ */
+export async function promptForProvider(): Promise<ProviderPromptResult> {
+  // Define available provider options
+  const providerOptions = [
+    { value: 'neon', label: 'Neon (serverless Postgres)' },
+    { value: 'turso', label: 'Turso (edge SQLite)' },
+    { value: 'planetscale', label: 'PlanetScale (MySQL-compatible)' },
+    { value: 'supabase', label: 'Supabase (Postgres DB only)' },
+    { value: 'postgres', label: 'Raw Postgres' },
+    { value: 'managed', label: 'Managed by BetterBase (coming soon)' },
+  ];
+
+  // Prompt for provider selection with re-prompt loop for "managed" option
+  let selectedProvider: string = '';
+  
+  while (!selectedProvider) {
+    const parsed = providerOptionsSchema.parse({
+      message: 'Which database provider would you like to use?',
+      options: providerOptions,
+      default: 'neon',
+    });
+
+    const response = await inquirer.prompt<{ value: string }>([
+      {
+        type: 'list',
+        name: 'value',
+        message: parsed.message,
+        choices: parsed.options.map((opt) => ({ name: opt.label, value: opt.value })),
+        default: parsed.default,
+      },
+    ]);
+
+    if (response.value === 'managed') {
+      // Show "coming soon" message and re-prompt
+      console.log('');
+      console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+      console.log('Coming soon — managed database launching in a future release.');
+      console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+      console.log('');
+      // Loop continues to re-prompt
+    } else {
+      selectedProvider = response.value;
+    }
+  }
+
+  const providerType = selectedProvider as ProviderType;
+  const envVars: Record<string, string> = {};
+
+  // Collect environment variables based on provider
+  const requiredVars = getRequiredEnvVars(providerType);
+
+  if (requiredVars.includes('DATABASE_URL') || requiredVars.includes('TURSO_URL')) {
+    if (providerType === 'turso') {
+      // Turso requires two env vars
+      const tursoUrlResponse = await inquirer.prompt<{ value: string }>([
+        {
+          type: 'input',
+          name: 'value',
+          message: 'TURSO_URL (libsql connection string)',
+          default: 'libsql://your-database.turso.io',
+        },
+      ]);
+      envVars['TURSO_URL'] = tursoUrlResponse.value;
+
+      const tursoTokenResponse = await inquirer.prompt<{ value: string }>([
+        {
+          type: 'input',
+          name: 'value',
+          message: 'TURSO_AUTH_TOKEN',
+          default: '',
+        },
+      ]);
+      envVars['TURSO_AUTH_TOKEN'] = tursoTokenResponse.value;
+    } else {
+      // Other providers use DATABASE_URL
+      const dbUrlResponse = await inquirer.prompt<{ value: string }>([
+        {
+          type: 'input',
+          name: 'value',
+          message: getDbUrlPromptMessage(providerType),
+          default: '',
+        },
+      ]);
+      envVars['DATABASE_URL'] = dbUrlResponse.value;
+    }
+  }
+
+  return {
+    providerType,
+    envVars,
+  };
+}
+
+/**
+ * Prompts for S3-compatible storage setup
+ * @returns Promise resolving to true if storage should be configured, false to skip
+ */
+export async function promptForStorage(): Promise<boolean> {
+  const response = await inquirer.prompt<{ value: boolean }>([
+    {
+      type: 'confirm',
+      name: 'value',
+      message: 'Set up S3-compatible storage now?',
+      default: false,
+    },
+  ]);
+
+  if (response.value) {
+    console.log('Storage setup coming in Phase 14');
+  }
+
+  return response.value;
+}
+
+/**
+ * Generates the .env file content with provider-specific environment variables
+ * @param providerType - The selected database provider type
+ * @param envVars - Map of environment variable names to their values
+ * @returns The formatted .env file content
+ */
+export function generateEnvContent(providerType: ProviderType, envVars: Record<string, string>): string {
+  let content = `NODE_ENV=development
+PORT=3000
+`;
+
+  // Add provider-specific env vars with comments
+  switch (providerType) {
+    case 'neon':
+      content += `
+# Database Provider: Neon
+# Get your connection string from https://console.neon.tech
+DATABASE_URL=${envVars.DATABASE_URL || ''}
+`;
+      break;
+    case 'turso':
+      content += `
+# Database Provider: Turso
+# Get your database URL from https://turso.tech
+TURSO_URL=${envVars.TURSO_URL || ''}
+TURSO_AUTH_TOKEN=${envVars.TURSO_AUTH_TOKEN || ''}
+`;
+      break;
+    case 'planetscale':
+      content += `
+# Database Provider: PlanetScale
+# Get your connection string from https://planetscale.com
+DATABASE_URL=${envVars.DATABASE_URL || ''}
+`;
+      break;
+    case 'supabase':
+      content += `
+# Database Provider: Supabase
+# Get your direct connection string from Supabase project settings
+DATABASE_URL=${envVars.DATABASE_URL || ''}
+`;
+      break;
+    case 'postgres':
+      content += `
+# Database Provider: PostgreSQL
+# Enter your PostgreSQL connection string
+DATABASE_URL=${envVars.DATABASE_URL || ''}
+`;
+      break;
+    case 'managed':
+      content += `
+# Database Provider: Managed by BetterBase
+# Managed database launching in a future release
+DATABASE_URL=${envVars.DATABASE_URL || ''}
+`;
+      break;
+  }
+
+  return content;
+}
+
+/**
+ * Generates the .env.example file content (without values)
+ * @param providerType - The selected database provider type
+ * @returns The formatted .env.example file content
+ */
+export function generateEnvExampleContent(providerType: ProviderType): string {
+  let content = `NODE_ENV=development
+PORT=3000
+`;
+
+  switch (providerType) {
+    case 'neon':
+    case 'planetscale':
+    case 'supabase':
+    case 'postgres':
+    case 'managed':
+      content += `
+# Database Provider: ${providerType}
+DATABASE_URL=
+`;
+      break;
+    case 'turso':
+      content += `
+# Database Provider: Turso
+TURSO_URL=
+TURSO_AUTH_TOKEN=
+`;
+      break;
+  }
+
+  return content;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,11 @@
     "hono": "^4.6.10",
     "drizzle-orm": "^0.44.5",
     "zod": "^3.23.8",
-    "@betterbase/shared": "workspace:*"
+    "@betterbase/shared": "workspace:*",
+    "@neondatabase/serverless": "latest",
+    "@libsql/client": "latest",
+    "@planetscale/database": "latest",
+    "postgres": "latest"
   },
   "devDependencies": {
     "typescript": "^5.6.0",

--- a/packages/core/src/config/drizzle-generator.ts
+++ b/packages/core/src/config/drizzle-generator.ts
@@ -1,0 +1,270 @@
+import type { ProviderType } from './schema'
+import type { BetterBaseConfig } from './schema'
+
+/**
+ * Drizzle driver types supported by the generator
+ */
+export type DrizzleDriver = 
+  | 'neon-serverless'  // Neon
+  | 'turso'            // Turso/libSQL
+  | 'mysql2'           // PlanetScale
+  | 'pg'               // PostgreSQL/Supabase
+  | 'better-sqlite'    // Local/SQLite
+
+/**
+ * Drizzle dialect types
+ */
+export type DrizzleDialect = 'postgresql' | 'mysql' | 'sqlite' | 'turso'
+
+/**
+ * Interface for database credentials in generated config
+ */
+export interface DbCredentials {
+  connectionString?: string
+  url?: string
+  uri?: string
+  authToken?: string
+}
+
+/**
+ * Generated drizzle configuration structure
+ */
+export interface DrizzleConfigOutput {
+  schema?: string
+  out?: string
+  dialect: DrizzleDialect
+  driver?: DrizzleDriver
+  dbCredentials: DbCredentials
+  verbose?: boolean
+  strict?: boolean
+}
+
+/**
+ * Generates a drizzle.config.ts file content based on the selected provider
+ * @param providerType - The database provider type
+ * @param config - The BetterBase configuration (used for custom schema/out paths)
+ * @returns A string containing the complete drizzle.config.ts file content
+ * @throws Error if the provider type is not supported
+ */
+export function generateDrizzleConfig(
+  providerType: ProviderType,
+  config?: Partial<BetterBaseConfig>
+): string {
+  const schemaPath = config?.project?.name ? './src/db/schema.ts' : './src/db/schema.ts'
+  const outPath = './drizzle'
+
+  switch (providerType) {
+    case 'neon':
+      return generateNeonConfig(schemaPath, outPath)
+    
+    case 'turso':
+      return generateTursoConfig(schemaPath, outPath)
+    
+    case 'planetscale':
+      return generatePlanetScaleConfig(schemaPath, outPath)
+    
+    case 'supabase':
+      return generateSupabaseConfig(schemaPath, outPath)
+    
+    case 'postgres':
+      return generatePostgresConfig(schemaPath, outPath)
+    
+    case 'managed':
+      return generateManagedConfig(schemaPath, outPath)
+    
+    default:
+      throw new Error(`Unsupported provider type: ${providerType}`)
+  }
+}
+
+/**
+ * Generates drizzle config for Neon database
+ * Uses postgresql dialect with neon-serverless driver
+ */
+function generateNeonConfig(schemaPath: string, outPath: string): string {
+  return `import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: '${schemaPath}',
+  out: '${outPath}',
+  dialect: 'postgresql',
+  driver: 'neon-serverless',
+  dbCredentials: {
+    connectionString: process.env.DATABASE_URL!
+  },
+  verbose: true,
+  strict: true,
+})
+`
+}
+
+/**
+ * Generates drizzle config for Turso (libSQL) database
+ * Uses turso dialect with turso driver
+ */
+function generateTursoConfig(schemaPath: string, outPath: string): string {
+  return `import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: '${schemaPath}',
+  out: '${outPath}',
+  dialect: 'turso',
+  driver: 'turso',
+  dbCredentials: {
+    url: process.env.TURSO_URL!,
+    authToken: process.env.TURSO_AUTH_TOKEN!
+  },
+  verbose: true,
+  strict: true,
+})
+`
+}
+
+/**
+ * Generates drizzle config for PlanetScale database
+ * Uses mysql dialect with mysql2 driver
+ */
+function generatePlanetScaleConfig(schemaPath: string, outPath: string): string {
+  return `import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: '${schemaPath}',
+  out: '${outPath}',
+  dialect: 'mysql',
+  driver: 'mysql2',
+  dbCredentials: {
+    uri: process.env.DATABASE_URL!
+  },
+  verbose: true,
+  strict: true,
+})
+`
+}
+
+/**
+ * Generates drizzle config for Supabase (PostgreSQL) database
+ * Uses postgresql dialect with pg driver
+ */
+function generateSupabaseConfig(schemaPath: string, outPath: string): string {
+  return `import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: '${schemaPath}',
+  out: '${outPath}',
+  dialect: 'postgresql',
+  driver: 'pg',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!
+  },
+  verbose: true,
+  strict: true,
+})
+`
+}
+
+/**
+ * Generates drizzle config for standard PostgreSQL database
+ * Uses postgresql dialect with pg driver
+ */
+function generatePostgresConfig(schemaPath: string, outPath: string): string {
+  return `import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: '${schemaPath}',
+  out: '${outPath}',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!
+  },
+  verbose: true,
+  strict: true,
+})
+`
+}
+
+/**
+ * Generates drizzle config for managed (BetterBase-hosted) database
+ * Uses sqlite dialect with better-sqlite driver for local development
+ */
+function generateManagedConfig(schemaPath: string, outPath: string): string {
+  return `import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: '${schemaPath}',
+  out: '${outPath}',
+  dialect: 'sqlite',
+  driver: 'better-sqlite',
+  dbCredentials: {
+    url: process.env.DATABASE_URL || 'file:local.db'
+  },
+  verbose: true,
+  strict: true,
+})
+`
+}
+
+/**
+ * Gets the appropriate dialect for a given provider type
+ * @param providerType - The database provider type
+ * @returns The Drizzle dialect string
+ */
+export function getDialectForProvider(providerType: ProviderType): DrizzleDialect {
+  switch (providerType) {
+    case 'neon':
+    case 'supabase':
+    case 'postgres':
+      return 'postgresql'
+    case 'planetscale':
+      return 'mysql'
+    case 'turso':
+      return 'turso'
+    case 'managed':
+      return 'sqlite'
+    default:
+      throw new Error(`Unsupported provider type: ${providerType}`)
+  }
+}
+
+/**
+ * Gets the appropriate driver for a given provider type
+ * @param providerType - The database provider type
+ * @returns The Drizzle driver string or undefined for default driver
+ */
+export function getDriverForProvider(providerType: ProviderType): DrizzleDriver | undefined {
+  switch (providerType) {
+    case 'neon':
+      return 'neon-serverless'
+    case 'turso':
+      return 'turso'
+    case 'planetscale':
+      return 'mysql2'
+    case 'managed':
+      return 'better-sqlite'
+    case 'supabase':
+    case 'postgres':
+      return undefined // Uses default pg driver
+    default:
+      throw new Error(`Unsupported provider type: ${providerType}`)
+  }
+}
+
+/**
+ * Gets the environment variables required for a given provider type
+ * @param providerType - The database provider type
+ * @returns Array of required environment variable names
+ */
+export function getRequiredEnvVars(providerType: ProviderType): string[] {
+  switch (providerType) {
+    case 'neon':
+    case 'supabase':
+    case 'postgres':
+    case 'planetscale':
+      return ['DATABASE_URL']
+    case 'turso':
+      return ['TURSO_URL', 'TURSO_AUTH_TOKEN']
+    case 'managed':
+      return ['DATABASE_URL'] // Optional, defaults to local.db
+    default:
+      return []
+  }
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,3 +1,30 @@
-// [stub] This module is implemented in Phase 10.2.
-// Do not implement here — wait for the Phase prompt.
-export {}
+/**
+ * BetterBase Configuration Module
+ * 
+ * This module provides configuration validation and Drizzle config generation
+ * for the BetterBase framework.
+ */
+
+// Re-export everything from schema
+export {
+  ProviderTypeSchema,
+  type ProviderType,
+  BetterBaseConfigSchema,
+  type BetterBaseConfig,
+  defineConfig,
+  validateConfig,
+  parseConfig,
+  assertConfig,
+} from './schema'
+
+// Re-export drizzle generator
+export {
+  generateDrizzleConfig,
+  getDialectForProvider,
+  getDriverForProvider,
+  getRequiredEnvVars,
+  type DrizzleDriver,
+  type DrizzleDialect,
+  type DrizzleConfigOutput,
+  type DbCredentials,
+} from './drizzle-generator'

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,14 +1,24 @@
 import { z } from 'zod'
 
+/**
+ * Supported database provider types in BetterBase
+ */
 export const ProviderTypeSchema = z.enum([
   'neon', 'turso', 'planetscale', 'supabase', 'postgres', 'managed'
 ])
 
+/**
+ * TypeScript type inferred from the ProviderTypeSchema
+ */
 export type ProviderType = z.infer<typeof ProviderTypeSchema>
 
+/**
+ * Zod schema for validating BetterBase configuration
+ * Defines the structure and validation rules for all config options
+ */
 export const BetterBaseConfigSchema = z.object({
   project: z.object({
-    name: z.string().min(1),
+    name: z.string().min(1, 'Project name is required'),
   }),
   provider: z.object({
     type: ProviderTypeSchema,
@@ -33,7 +43,7 @@ export const BetterBaseConfigSchema = z.object({
   graphql: z.object({
     enabled: z.boolean().default(true),
   }).optional(),
-}).superRefine((data, ctx) => {
+}).superRefine((data: { provider: { type: ProviderType; connectionString?: string; url?: string; authToken?: string } }, ctx) => {
   const { provider } = data;
   
   // Turso-specific validation: require both url and authToken
@@ -52,8 +62,8 @@ export const BetterBaseConfigSchema = z.object({
         path: ['provider', 'authToken'],
       });
     }
-  } else {
-    // Other providers require connectionString
+  } else if (provider.type !== 'managed') {
+    // Other providers require connectionString (except managed which has no DB)
     if (!provider.connectionString || provider.connectionString.trim() === '') {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -64,8 +74,51 @@ export const BetterBaseConfigSchema = z.object({
   }
 });
 
+/**
+ * TypeScript type inferred from the BetterBaseConfigSchema
+ * Represents the validated configuration structure
+ */
 export type BetterBaseConfig = z.infer<typeof BetterBaseConfigSchema>
 
+/**
+ * Creates a validated BetterBaseConfig from input data
+ * @param config - The configuration object to validate
+ * @returns The validated configuration
+ * @throws ZodError if validation fails
+ */
 export function defineConfig(config: z.input<typeof BetterBaseConfigSchema>): BetterBaseConfig {
   return BetterBaseConfigSchema.parse(config)
+}
+
+/**
+ * Validates a configuration object and returns a boolean result
+ * @param config - The configuration to validate
+ * @returns true if the configuration is valid, false otherwise
+ */
+export function validateConfig(config: unknown): boolean {
+  return BetterBaseConfigSchema.safeParse(config).success
+}
+
+/**
+ * Safely parses a configuration object
+ * @param config - The configuration to parse
+ * @returns Result containing either the validated config or error
+ */
+export function parseConfig(config: unknown): z.SafeParseReturnType<unknown, BetterBaseConfig> {
+  return BetterBaseConfigSchema.safeParse(config)
+}
+
+/**
+ * Validates the configuration and throws a descriptive error if invalid
+ * @param config - The configuration to validate
+ * @throws ZodError with detailed error messages if validation fails
+ */
+export function assertConfig(config: unknown): asserts config is BetterBaseConfig {
+  const result = BetterBaseConfigSchema.safeParse(config)
+  if (!result.success) {
+    const errors = result.error.issues.map((e) => 
+      `${e.path.join('.')}: ${e.message}`
+    ).join('; ')
+    throw new Error(`Invalid BetterBase configuration: ${errors}`)
+  }
 }

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -1,3 +1,226 @@
-// [stub] This module is implemented in Phase 10.1.
-// Do not implement here — wait for the Phase prompt.
-export {}
+// Provider types and interfaces
+export {
+  type ProviderAdapter,
+  type ProviderConfig,
+  type DatabaseConnection,
+  type DrizzleMigrationDriver,
+  type DatabaseDialect,
+  type NeonDatabaseConnection,
+  type TursoDatabaseConnection,
+  type PlanetScaleDatabaseConnection,
+  type SupabaseDatabaseConnection,
+  type PostgresDatabaseConnection,
+  type NeonMigrationDriver,
+  type TursoMigrationDriver,
+  type PlanetScaleMigrationDriver,
+  type SupabaseMigrationDriver,
+  type PostgresMigrationDriver,
+  ProviderConfigSchema,
+  NeonProviderConfigSchema,
+  TursoProviderConfigSchema,
+  PlanetScaleProviderConfigSchema,
+  SupabaseProviderConfigSchema,
+  PostgresProviderConfigSchema,
+  ManagedProviderConfigSchema,
+  isValidProviderConfig,
+  parseProviderConfig,
+  safeParseProviderConfig,
+} from './types'
+
+// Provider adapters
+export { NeonProviderAdapter, createNeonProvider } from './neon'
+export { TursoProviderAdapter, createTursoProvider } from './turso'
+export { PlanetScaleProviderAdapter, createPlanetScaleProvider } from './planetscale'
+export { SupabaseProviderAdapter, createSupabaseProvider } from './supabase'
+export { PostgresProviderAdapter, createPostgresProvider } from './postgres'
+
+import type { ProviderAdapter, ProviderConfig } from './types'
+import { NeonProviderAdapter } from './neon'
+import { TursoProviderAdapter } from './turso'
+import { PlanetScaleProviderAdapter } from './planetscale'
+import { SupabaseProviderAdapter } from './supabase'
+import { PostgresProviderAdapter } from './postgres'
+import type { ProviderType } from '@betterbase/shared'
+import { parseProviderConfig } from './types'
+
+/**
+ * Error thrown when the 'managed' provider type is selected
+ * This is a placeholder for future implementation
+ */
+export class ManagedProviderNotSupportedError extends Error {
+  constructor() {
+    super(
+      'The "managed" provider type is not yet supported. ' +
+      'This feature is coming soon. Please use one of the supported providers: ' +
+      'neon, turso, planetscale, supabase, or postgres.'
+    )
+    this.name = 'ManagedProviderNotSupportedError'
+  }
+}
+
+/**
+ * Resolve the appropriate provider adapter based on the configuration
+ * 
+ * @param config - The provider configuration from BetterBase config
+ * @returns The appropriate ProviderAdapter instance
+ * @throws ManagedProviderNotSupportedError if provider type is 'managed'
+ * @throws Error if provider type is unknown
+ * 
+ * @example
+ * ```typescript
+ * import { resolveProvider } from '@betterbase/core/providers'
+ * 
+ * const adapter = resolveProvider({
+ *   type: 'neon',
+ *   connectionString: process.env.DATABASE_URL
+ * })
+ * 
+ * const connection = await adapter.connect(config)
+ * console.log(adapter.supportsRLS()) // true
+ * ```
+ */
+export function resolveProvider(config: ProviderConfig): ProviderAdapter {
+  // First validate the config
+  const validatedConfig = parseProviderConfig(config)
+  
+  const providerType = validatedConfig.type
+
+  switch (providerType) {
+    case 'neon':
+      return new NeonProviderAdapter()
+    
+    case 'turso':
+      return new TursoProviderAdapter()
+    
+    case 'planetscale':
+      return new PlanetScaleProviderAdapter()
+    
+    case 'supabase':
+      return new SupabaseProviderAdapter()
+    
+    case 'postgres':
+      return new PostgresProviderAdapter()
+    
+    case 'managed':
+      throw new ManagedProviderNotSupportedError()
+    
+    default:
+      // This should never happen due to Zod validation
+      // but TypeScript needs exhaustive checking
+      const _exhaustive: never = providerType
+      throw new Error(`Unknown provider type: ${_exhaustive}`)
+  }
+}
+
+/**
+ * Resolve provider by provider type string (without full config validation)
+ * Useful when you just need to create the adapter before connecting
+ * 
+ * @param providerType - The type of provider to create
+ * @returns The appropriate ProviderAdapter instance
+ * @throws ManagedProviderNotSupportedError if provider type is 'managed'
+ * 
+ * @example
+ * ```typescript
+ * import { resolveProviderByType } from '@betterbase/core/providers'
+ * 
+ * const adapter = resolveProviderByType('neon')
+ * await adapter.connect({ type: 'neon', connectionString: '...' })
+ * ```
+ */
+export function resolveProviderByType(providerType: ProviderType): ProviderAdapter {
+  switch (providerType) {
+    case 'neon':
+      return new NeonProviderAdapter()
+    
+    case 'turso':
+      return new TursoProviderAdapter()
+    
+    case 'planetscale':
+      return new PlanetScaleProviderAdapter()
+    
+    case 'supabase':
+      return new SupabaseProviderAdapter()
+    
+    case 'postgres':
+      return new PostgresProviderAdapter()
+    
+    case 'managed':
+      throw new ManagedProviderNotSupportedError()
+    
+    default:
+      // This should never happen due to type checking
+      const _exhaustive: never = providerType
+      throw new Error(`Unknown provider type: ${_exhaustive}`)
+  }
+}
+
+/**
+ * Get a list of all supported provider types
+ * 
+ * @returns Array of supported provider type strings
+ * 
+ * @example
+ * ```typescript
+ * import { getSupportedProviders } from '@betterbase/core/providers'
+ * 
+ * console.log(getSupportedProviders())
+ * // ['neon', 'turso', 'planetscale', 'supabase', 'postgres']
+ * ```
+ */
+export function getSupportedProviders(): Exclude<ProviderType, 'managed'>[] {
+  return ['neon', 'turso', 'planetscale', 'supabase', 'postgres']
+}
+
+/**
+ * Check if a provider type supports Row Level Security
+ * 
+ * @param providerType - The type of provider to check
+ * @returns true if the provider supports RLS
+ * 
+ * @example
+ * ```typescript
+ * import { providerSupportsRLS } from '@betterbase/core/providers'
+ * 
+ * console.log(providerSupportsRLS('neon'))    // true
+ * console.log(providerSupportsRLS('turso'))  // false
+ * ```
+ */
+export function providerSupportsRLS(providerType: ProviderType): boolean {
+  // RLS is not supported by Turso (SQLite) and PlanetScale (MySQL)
+  const noRLSProviders: ProviderType[] = ['turso', 'planetscale']
+  return !noRLSProviders.includes(providerType)
+}
+
+/**
+ * Get the SQL dialect for a provider type
+ * 
+ * @param providerType - The type of provider
+ * @returns The SQL dialect string
+ * 
+ * @example
+ * ```typescript
+ * import { getProviderDialect } from '@betterbase/core/providers'
+ * 
+ * console.log(getProviderDialect('neon'))       // 'postgres'
+ * console.log(getProviderDialect('turso'))       // 'sqlite'
+ * console.log(getProviderDialect('planetscale')) // 'mysql'
+ * ```
+ */
+export function getProviderDialect(providerType: ProviderType): 'postgres' | 'mysql' | 'sqlite' {
+  switch (providerType) {
+    case 'neon':
+    case 'supabase':
+    case 'postgres':
+      return 'postgres'
+    case 'planetscale':
+      return 'mysql'
+    case 'turso':
+      return 'sqlite'
+    case 'managed':
+      throw new ManagedProviderNotSupportedError()
+    default:
+      const _exhaustive: never = providerType
+      throw new Error(`Unknown provider type: ${_exhaustive}`)
+  }
+}

--- a/packages/core/src/providers/neon.ts
+++ b/packages/core/src/providers/neon.ts
@@ -1,0 +1,134 @@
+import { neon } from '@neondatabase/serverless'
+import type { ProviderAdapter, DatabaseConnection, DrizzleMigrationDriver, ProviderConfig, NeonDatabaseConnection } from './types'
+import { parseProviderConfig } from './types'
+import type { ProviderType } from '@betterbase/shared'
+
+// Type for the Neon client - the neon() function returns a query function
+// that can be used directly with drizzle-orm
+type NeonClient = ReturnType<typeof neon>
+
+/**
+ * Neon-specific database connection implementation
+ */
+class NeonConnection implements NeonDatabaseConnection {
+  readonly provider: 'neon' = 'neon'
+  readonly neon: NeonClient
+  // Store the drizzle-compatible client for use with drizzle-orm
+  readonly drizzle: NeonClient
+  private _isConnected: boolean = false
+
+  constructor(connectionString: string) {
+    this.neon = neon(connectionString)
+    this.drizzle = this.neon
+    this._isConnected = true
+  }
+
+  async close(): Promise<void> {
+    // Neon serverless connections don't need explicit closing
+    // but we mark as disconnected
+    this._isConnected = false
+  }
+
+  isConnected(): boolean {
+    return this._isConnected
+  }
+}
+
+/**
+ * Neon migration driver implementation
+ */
+class NeonMigrationDriver implements DrizzleMigrationDriver {
+  private readonly connectionString: string
+
+  constructor(connectionString: string) {
+    this.connectionString = connectionString
+  }
+
+  async migrate(_migrations: string[], _direction: 'up' | 'down'): Promise<void> {
+    // Migration implementation would go here
+    // For now, this is a placeholder
+    console.log('Running migrations with Neon driver...')
+  }
+
+  async createMigrationTable(): Promise<void> {
+    // Create the __drizzle_migrations table if it doesn't exist
+    console.log('Creating migration table with Neon driver...')
+  }
+
+  async getPendingMigrations(): Promise<string[]> {
+    // Return list of pending migrations
+    return []
+  }
+}
+
+/**
+ * Neon database provider adapter
+ * Implements the ProviderAdapter interface for Neon (serverless Postgres)
+ */
+export class NeonProviderAdapter implements ProviderAdapter {
+  readonly type: ProviderType = 'neon'
+  readonly dialect: 'postgres' = 'postgres'
+  private _connectionString: string | null = null
+
+  /**
+   * Connect to a Neon database
+   * @param config - The provider configuration
+   * @returns A promise that resolves to a Neon database connection
+   */
+  async connect(config: ProviderConfig): Promise<DatabaseConnection> {
+    const validatedConfig = parseProviderConfig(config)
+    
+    if (validatedConfig.type !== 'neon') {
+      throw new Error('Invalid configuration: expected Neon provider config')
+    }
+
+    const connectionString = validatedConfig.connectionString
+    
+    if (!connectionString) {
+      throw new Error('Neon provider requires a connectionString')
+    }
+
+    // Store connection string for later use by getMigrationsDriver
+    this._connectionString = connectionString
+
+    return new NeonConnection(connectionString)
+  }
+
+  /**
+   * Get the migrations driver for Neon
+   * @returns A Neon migration driver instance
+   */
+  getMigrationsDriver(): DrizzleMigrationDriver {
+    if (!this._connectionString) {
+      throw new Error('Migration driver not initialized. Call connect() first.')
+    }
+    return new NeonMigrationDriver(this._connectionString)
+  }
+
+  /**
+   * Neon supports Row Level Security (RLS)
+   * @returns true as Neon is built on PostgreSQL
+   */
+  supportsRLS(): boolean {
+    return true
+  }
+
+  /**
+   * Neon supports GraphQL (via PostgreSQL)
+   * @returns true
+   */
+  supportsGraphQL(): boolean {
+    return true
+  }
+}
+
+/**
+ * Create a new Neon provider adapter instance
+ * @returns A new NeonProviderAdapter instance
+ */
+export function createNeonProvider(): NeonProviderAdapter {
+  return new NeonProviderAdapter()
+}
+
+// Export the adapter as default for convenience
+export default NeonProviderAdapter

--- a/packages/core/src/providers/planetscale.ts
+++ b/packages/core/src/providers/planetscale.ts
@@ -1,0 +1,134 @@
+import { connect } from '@planetscale/database'
+import type { ProviderAdapter, DatabaseConnection, DrizzleMigrationDriver, ProviderConfig, PlanetScaleDatabaseConnection } from './types'
+import { parseProviderConfig } from './types'
+import type { ProviderType } from '@betterbase/shared'
+
+// Type for the PlanetScale connection
+type PlanetScaleClient = ReturnType<typeof connect>
+
+/**
+ * PlanetScale-specific database connection implementation
+ */
+class PlanetScaleConnectionImpl implements PlanetScaleDatabaseConnection {
+  readonly provider: 'planetscale' = 'planetscale'
+  readonly planetscale: PlanetScaleClient
+  // Store the drizzle-compatible client for use with drizzle-orm
+  readonly drizzle: PlanetScaleClient
+  private _isConnected: boolean = false
+
+  constructor(connectionString: string) {
+    this.planetscale = connect({
+      url: connectionString,
+    })
+    this.drizzle = this.planetscale
+    this._isConnected = true
+  }
+
+  async close(): Promise<void> {
+    // PlanetScale connections are HTTP-based and don't need explicit closing
+    this._isConnected = false
+  }
+
+  isConnected(): boolean {
+    return this._isConnected
+  }
+}
+
+/**
+ * PlanetScale migration driver implementation
+ */
+class PlanetScaleMigrationDriver implements DrizzleMigrationDriver {
+  private readonly connectionString: string
+
+  constructor(connectionString: string) {
+    this.connectionString = connectionString
+  }
+
+  async migrate(_migrations: string[], _direction: 'up' | 'down'): Promise<void> {
+    // Migration implementation would go here
+    // For now, this is a placeholder
+    console.log('Running migrations with PlanetScale driver...')
+  }
+
+  async createMigrationTable(): Promise<void> {
+    // Create the __drizzle_migrations table if it doesn't exist
+    console.log('Creating migration table with PlanetScale driver...')
+  }
+
+  async getPendingMigrations(): Promise<string[]> {
+    // Return list of pending migrations
+    return []
+  }
+}
+
+/**
+ * PlanetScale database provider adapter
+ * Implements the ProviderAdapter interface for PlanetScale (MySQL-compatible)
+ */
+export class PlanetScaleProviderAdapter implements ProviderAdapter {
+  readonly type: ProviderType = 'planetscale'
+  readonly dialect: 'mysql' = 'mysql'
+  private _connectionString: string | null = null
+
+  /**
+   * Connect to a PlanetScale database
+   * @param config - The provider configuration
+   * @returns A promise that resolves to a PlanetScale database connection
+   */
+  async connect(config: ProviderConfig): Promise<DatabaseConnection> {
+    const validatedConfig = parseProviderConfig(config)
+    
+    if (validatedConfig.type !== 'planetscale') {
+      throw new Error('Invalid configuration: expected PlanetScale provider config')
+    }
+
+    const connectionString = validatedConfig.connectionString
+    
+    if (!connectionString) {
+      throw new Error('PlanetScale provider requires a connectionString')
+    }
+
+    // Store connection string for later use by getMigrationsDriver
+    this._connectionString = connectionString
+
+    return new PlanetScaleConnectionImpl(connectionString)
+  }
+
+  /**
+   * Get the migrations driver for PlanetScale
+   * @returns A PlanetScale migration driver instance
+   */
+  getMigrationsDriver(): DrizzleMigrationDriver {
+    if (!this._connectionString) {
+      throw new Error('Migration driver not initialized. Call connect() first.')
+    }
+    return new PlanetScaleMigrationDriver(this._connectionString)
+  }
+
+  /**
+   * PlanetScale does not support Row Level Security (RLS)
+   * @returns false as PlanetScale is MySQL-compatible and doesn't have RLS
+   */
+  supportsRLS(): boolean {
+    return false
+  }
+
+  /**
+   * PlanetScale has limited GraphQL support (via MySQL)
+   * @returns false as native GraphQL requires PostgreSQL
+   */
+  supportsGraphQL(): boolean {
+    return false
+  }
+}
+
+/**
+ * Create a new PlanetScale provider adapter instance
+ * @returns A new PlanetScaleProviderAdapter instance
+ */
+export function createPlanetScaleProvider(): PlanetScaleProviderAdapter {
+  return new PlanetScaleProviderAdapter()
+}
+
+// Export the adapter as default for convenience
+export default PlanetScaleProviderAdapter

--- a/packages/core/src/providers/postgres.ts
+++ b/packages/core/src/providers/postgres.ts
@@ -1,0 +1,132 @@
+import postgres from 'postgres'
+import type { ProviderAdapter, DatabaseConnection, DrizzleMigrationDriver, ProviderConfig, PostgresDatabaseConnection } from './types'
+import { parseProviderConfig } from './types'
+import type { ProviderType } from '@betterbase/shared'
+
+// Type for the Postgres client
+type PostgresClient = ReturnType<typeof postgres>
+
+/**
+ * Standard Postgres-specific database connection implementation
+ */
+class PostgresConnection implements PostgresDatabaseConnection {
+  readonly provider: 'postgres' = 'postgres'
+  readonly postgres: PostgresClient
+  // Store the drizzle-compatible client for use with drizzle-orm
+  readonly drizzle: PostgresClient
+  private _isConnected: boolean = false
+
+  constructor(connectionString: string) {
+    this.postgres = postgres(connectionString)
+    this.drizzle = this.postgres
+    this._isConnected = true
+  }
+
+  async close(): Promise<void> {
+    await this.postgres.end()
+    this._isConnected = false
+  }
+
+  isConnected(): boolean {
+    return this._isConnected
+  }
+}
+
+/**
+ * Standard Postgres migration driver implementation
+ */
+class PostgresMigrationDriver implements DrizzleMigrationDriver {
+  private readonly connectionString: string
+
+  constructor(connectionString: string) {
+    this.connectionString = connectionString
+  }
+
+  async migrate(_migrations: string[], _direction: 'up' | 'down'): Promise<void> {
+    // Migration implementation would go here
+    // For now, this is a placeholder
+    console.log('Running migrations with Postgres driver...')
+  }
+
+  async createMigrationTable(): Promise<void> {
+    // Create the __drizzle_migrations table if it doesn't exist
+    console.log('Creating migration table with Postgres driver...')
+  }
+
+  async getPendingMigrations(): Promise<string[]> {
+    // Return list of pending migrations
+    return []
+  }
+}
+
+/**
+ * Standard Postgres database provider adapter
+ * Implements the ProviderAdapter interface for standard Postgres connections
+ */
+export class PostgresProviderAdapter implements ProviderAdapter {
+  readonly type: ProviderType = 'postgres'
+  readonly dialect: 'postgres' = 'postgres'
+  private _connectionString: string | null = null
+
+  /**
+   * Connect to a standard Postgres database
+   * @param config - The provider configuration
+   * @returns A promise that resolves to a Postgres database connection
+   */
+  async connect(config: ProviderConfig): Promise<DatabaseConnection> {
+    const validatedConfig = parseProviderConfig(config)
+    
+    if (validatedConfig.type !== 'postgres') {
+      throw new Error('Invalid configuration: expected Postgres provider config')
+    }
+
+    const connectionString = validatedConfig.connectionString
+    
+    if (!connectionString) {
+      throw new Error('Postgres provider requires a connectionString')
+    }
+
+    // Store connection string for later use by getMigrationsDriver
+    this._connectionString = connectionString
+
+    return new PostgresConnection(connectionString)
+  }
+
+  /**
+   * Get the migrations driver for standard Postgres
+   * @returns A Postgres migration driver instance
+   */
+  getMigrationsDriver(): DrizzleMigrationDriver {
+    if (!this._connectionString) {
+      throw new Error('Migration driver not initialized. Call connect() first.')
+    }
+    return new PostgresMigrationDriver(this._connectionString)
+  }
+
+  /**
+   * Standard Postgres supports Row Level Security (RLS)
+   * @returns true as Postgres has built-in RLS support
+   */
+  supportsRLS(): boolean {
+    return true
+  }
+
+  /**
+   * Standard Postgres supports GraphQL
+   * @returns true
+   */
+  supportsGraphQL(): boolean {
+    return true
+  }
+}
+
+/**
+ * Create a new standard Postgres provider adapter instance
+ * @returns A new PostgresProviderAdapter instance
+ */
+export function createPostgresProvider(): PostgresProviderAdapter {
+  return new PostgresProviderAdapter()
+}
+
+// Export the adapter as default for convenience
+export default PostgresProviderAdapter

--- a/packages/core/src/providers/supabase.ts
+++ b/packages/core/src/providers/supabase.ts
@@ -1,0 +1,134 @@
+import postgres from 'postgres'
+import type { ProviderAdapter, DatabaseConnection, DrizzleMigrationDriver, ProviderConfig, SupabaseDatabaseConnection } from './types'
+import { parseProviderConfig } from './types'
+import type { ProviderType } from '@betterbase/shared'
+
+// Type for the Postgres client (used by Supabase)
+type PostgresClient = ReturnType<typeof postgres>
+
+/**
+ * Supabase-specific database connection implementation
+ * Uses direct Postgres connection (NOT @supabase/supabase-js)
+ */
+class SupabaseConnection implements SupabaseDatabaseConnection {
+  readonly provider: 'supabase' = 'supabase'
+  readonly postgres: PostgresClient
+  // Store the drizzle-compatible client for use with drizzle-orm
+  readonly drizzle: PostgresClient
+  private _isConnected: boolean = false
+
+  constructor(connectionString: string) {
+    this.postgres = postgres(connectionString)
+    this.drizzle = this.postgres
+    this._isConnected = true
+  }
+
+  async close(): Promise<void> {
+    await this.postgres.end()
+    this._isConnected = false
+  }
+
+  isConnected(): boolean {
+    return this._isConnected
+  }
+}
+
+/**
+ * Supabase migration driver implementation
+ */
+class SupabaseMigrationDriver implements DrizzleMigrationDriver {
+  private readonly connectionString: string
+
+  constructor(connectionString: string) {
+    this.connectionString = connectionString
+  }
+
+  async migrate(_migrations: string[], _direction: 'up' | 'down'): Promise<void> {
+    // Migration implementation would go here
+    // For now, this is a placeholder
+    console.log('Running migrations with Supabase driver...')
+  }
+
+  async createMigrationTable(): Promise<void> {
+    // Create the __drizzle_migrations table if it doesn't exist
+    console.log('Creating migration table with Supabase driver...')
+  }
+
+  async getPendingMigrations(): Promise<string[]> {
+    // Return list of pending migrations
+    return []
+  }
+}
+
+/**
+ * Supabase database provider adapter
+ * Implements the ProviderAdapter (managed Postgres)
+ interface for Supabase * Uses direct Postgres connection, NOT @supabase/supabase-js
+ */
+export class SupabaseProviderAdapter implements ProviderAdapter {
+  readonly type: ProviderType = 'supabase'
+  readonly dialect: 'postgres' = 'postgres'
+  private _connectionString: string | null = null
+
+  /**
+   * Connect to a Supabase database
+   * @param config - The provider configuration
+   * @returns A promise that resolves to a Supabase database connection
+   */
+  async connect(config: ProviderConfig): Promise<DatabaseConnection> {
+    const validatedConfig = parseProviderConfig(config)
+    
+    if (validatedConfig.type !== 'supabase') {
+      throw new Error('Invalid configuration: expected Supabase provider config')
+    }
+
+    const connectionString = validatedConfig.connectionString
+    
+    if (!connectionString) {
+      throw new Error('Supabase provider requires a connectionString')
+    }
+
+    // Store connection string for later use by getMigrationsDriver
+    this._connectionString = connectionString
+
+    return new SupabaseConnection(connectionString)
+  }
+
+  /**
+   * Get the migrations driver for Supabase
+   * @returns A Supabase migration driver instance
+   */
+  getMigrationsDriver(): DrizzleMigrationDriver {
+    if (!this._connectionString) {
+      throw new Error('Migration driver not initialized. Call connect() first.')
+    }
+    return new SupabaseMigrationDriver(this._connectionString)
+  }
+
+  /**
+   * Supabase supports Row Level Security (RLS)
+   * @returns true as Supabase is built on PostgreSQL with RLS support
+   */
+  supportsRLS(): boolean {
+    return true
+  }
+
+  /**
+   * Supabase supports GraphQL (via PostgreSQL)
+   * @returns true
+   */
+  supportsGraphQL(): boolean {
+    return true
+  }
+}
+
+/**
+ * Create a new Supabase provider adapter instance
+ * @returns A new SupabaseProviderAdapter instance
+ */
+export function createSupabaseProvider(): SupabaseProviderAdapter {
+  return new SupabaseProviderAdapter()
+}
+
+// Export the adapter as default for convenience
+export default SupabaseProviderAdapter

--- a/packages/core/src/providers/turso.ts
+++ b/packages/core/src/providers/turso.ts
@@ -1,0 +1,144 @@
+import { createClient } from '@libsql/client'
+import type { ProviderAdapter, DatabaseConnection, DrizzleMigrationDriver, ProviderConfig, TursoDatabaseConnection } from './types'
+import { parseProviderConfig } from './types'
+import type { ProviderType } from '@betterbase/shared'
+
+// Type for the Turso client
+type TursoClient = ReturnType<typeof createClient>
+
+/**
+ * Turso-specific database connection implementation
+ */
+class TursoConnection implements TursoDatabaseConnection {
+  readonly provider: 'turso' = 'turso'
+  readonly libsql: TursoClient
+  // Store the drizzle-compatible client for use with drizzle-orm
+  readonly drizzle: TursoClient
+  private _isConnected: boolean = false
+
+  constructor(url: string, authToken: string) {
+    this.libsql = createClient({
+      url,
+      authToken,
+    })
+    this.drizzle = this.libsql
+    this._isConnected = true
+  }
+
+  async close(): Promise<void> {
+    await this.libsql.close()
+    this._isConnected = false
+  }
+
+  isConnected(): boolean {
+    return this._isConnected
+  }
+}
+
+/**
+ * Turso migration driver implementation
+ */
+class TursoMigrationDriver implements DrizzleMigrationDriver {
+  private readonly url: string
+  private readonly authToken: string
+
+  constructor(url: string, authToken: string) {
+    this.url = url
+    this.authToken = authToken
+  }
+
+  async migrate(_migrations: string[], _direction: 'up' | 'down'): Promise<void> {
+    // Migration implementation would go here
+    // For now, this is a placeholder
+    console.log('Running migrations with Turso driver...')
+  }
+
+  async createMigrationTable(): Promise<void> {
+    // Create the __drizzle_migrations table if it doesn't exist
+    console.log('Creating migration table with Turso driver...')
+  }
+
+  async getPendingMigrations(): Promise<string[]> {
+    // Return list of pending migrations
+    return []
+  }
+}
+
+/**
+ * Turso database provider adapter
+ * Implements the ProviderAdapter interface for Turso (libSQL/SQLite)
+ */
+export class TursoProviderAdapter implements ProviderAdapter {
+  readonly type: ProviderType = 'turso'
+  readonly dialect: 'sqlite' = 'sqlite'
+  private _connectionConfig: { url: string; authToken: string } | null = null
+
+  /**
+   * Connect to a Turso database
+   * @param config - The provider configuration
+   * @returns A promise that resolves to a Turso database connection
+   */
+  async connect(config: ProviderConfig): Promise<DatabaseConnection> {
+    const validatedConfig = parseProviderConfig(config)
+    
+    if (validatedConfig.type !== 'turso') {
+      throw new Error('Invalid configuration: expected Turso provider config')
+    }
+
+    const { url, authToken } = validatedConfig
+    
+    if (!url) {
+      throw new Error('Turso provider requires a url')
+    }
+
+    if (!authToken) {
+      throw new Error('Turso provider requires an authToken')
+    }
+
+    // Store config for later use by getMigrationsDriver
+    this._connectionConfig = { url, authToken }
+
+    return new TursoConnection(url, authToken)
+  }
+
+  /**
+   * Get the migrations driver for Turso
+   * @returns A Turso migration driver instance
+   */
+  getMigrationsDriver(): DrizzleMigrationDriver {
+    if (!this._connectionConfig) {
+      throw new Error('Migration driver not initialized. Call connect() first.')
+    }
+    return new TursoMigrationDriver(
+      this._connectionConfig.url,
+      this._connectionConfig.authToken
+    )
+  }
+
+  /**
+   * Turso (libSQL) does not support Row Level Security (RLS)
+   * @returns false as Turso uses SQLite which doesn't have RLS
+   */
+  supportsRLS(): boolean {
+    return false
+  }
+
+  /**
+   * Turso has limited GraphQL support (via SQLite)
+   * @returns false as native GraphQL requires PostgreSQL
+   */
+  supportsGraphQL(): boolean {
+    return false
+  }
+}
+
+/**
+ * Create a new Turso provider adapter instance
+ * @returns A new TursoProviderAdapter instance
+ */
+export function createTursoProvider(): TursoProviderAdapter {
+  return new TursoProviderAdapter()
+}
+
+// Export the adapter as default for convenience
+export default TursoProviderAdapter

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -1,20 +1,216 @@
+import { z } from 'zod'
 import type { ProviderType } from '@betterbase/shared'
 
+/**
+ * Dialect types supported by the database providers
+ */
+export type DatabaseDialect = 'postgres' | 'mysql' | 'sqlite'
+
+/**
+ * Provider-specific configuration schemas for Zod validation
+ */
+export const NeonProviderConfigSchema = z.object({
+  type: z.literal('neon'),
+  connectionString: z.string().min(1),
+})
+
+export const TursoProviderConfigSchema = z.object({
+  type: z.literal('turso'),
+  url: z.string().min(1),
+  authToken: z.string().min(1),
+})
+
+export const PlanetScaleProviderConfigSchema = z.object({
+  type: z.literal('planetscale'),
+  connectionString: z.string().min(1),
+})
+
+export const SupabaseProviderConfigSchema = z.object({
+  type: z.literal('supabase'),
+  connectionString: z.string().min(1),
+})
+
+export const PostgresProviderConfigSchema = z.object({
+  type: z.literal('postgres'),
+  connectionString: z.string().min(1),
+})
+
+export const ManagedProviderConfigSchema = z.object({
+  type: z.literal('managed'),
+})
+
+/**
+ * Union of all provider configuration schemas
+ */
+export const ProviderConfigSchema = z.discriminatedUnion('type', [
+  NeonProviderConfigSchema,
+  TursoProviderConfigSchema,
+  PlanetScaleProviderConfigSchema,
+  SupabaseProviderConfigSchema,
+  PostgresProviderConfigSchema,
+  ManagedProviderConfigSchema,
+])
+
+/**
+ * Configuration for connecting to a database provider
+ * Each provider has different required fields
+ */
+export type ProviderConfig = z.infer<typeof ProviderConfigSchema>
+
+/**
+ * Drizzle Migration Driver type
+ * Used for running migrations against the database
+ */
+export interface DrizzleMigrationDriver {
+  migrate(migrations: string[], direction: 'up' | 'down'): Promise<void>
+  createMigrationTable(): Promise<void>
+  getPendingMigrations(): Promise<string[]>
+}
+
+/**
+ * Neon-specific migration driver implementation
+ */
+export interface NeonMigrationDriver extends DrizzleMigrationDriver {
+  readonly provider: 'neon'
+}
+
+/**
+ * Turso-specific migration driver implementation
+ */
+export interface TursoMigrationDriver extends DrizzleMigrationDriver {
+  readonly provider: 'turso'
+}
+
+/**
+ * PlanetScale-specific migration driver implementation
+ */
+export interface PlanetScaleMigrationDriver extends DrizzleMigrationDriver {
+  readonly provider: 'planetscale'
+}
+
+/**
+ * Supabase-specific migration driver implementation
+ */
+export interface SupabaseMigrationDriver extends DrizzleMigrationDriver {
+  readonly provider: 'supabase'
+}
+
+/**
+ * Standard Postgres migration driver implementation
+ */
+export interface PostgresMigrationDriver extends DrizzleMigrationDriver {
+  readonly provider: 'postgres'
+}
+
+/**
+ * Database connection wrapper that encapsulates the drizzle instance
+ * and provides provider-specific functionality
+ */
+export interface DatabaseConnection {
+  /** The underlying drizzle ORM instance */
+  readonly drizzle: unknown
+  /** Close the database connection */
+  close(): Promise<void>
+  /** Get the connection status */
+  isConnected(): boolean
+}
+
+/**
+ * Neon-specific database connection
+ */
+export interface NeonDatabaseConnection extends DatabaseConnection {
+  readonly provider: 'neon'
+  readonly neon: unknown
+}
+
+/**
+ * Turso-specific database connection
+ */
+export interface TursoDatabaseConnection extends DatabaseConnection {
+  readonly provider: 'turso'
+  readonly libsql: unknown
+}
+
+/**
+ * PlanetScale-specific database connection
+ */
+export interface PlanetScaleDatabaseConnection extends DatabaseConnection {
+  readonly provider: 'planetscale'
+  readonly planetscale: unknown
+}
+
+/**
+ * Supabase-specific database connection
+ */
+export interface SupabaseDatabaseConnection extends DatabaseConnection {
+  readonly provider: 'supabase'
+  readonly postgres: unknown
+}
+
+/**
+ * Standard Postgres database connection
+ */
+export interface PostgresDatabaseConnection extends DatabaseConnection {
+  readonly provider: 'postgres'
+  readonly postgres: unknown
+}
+
+/**
+ * Provider adapter interface that all database providers must implement
+ * This ensures a consistent API regardless of the underlying database technology
+ */
 export interface ProviderAdapter {
-  type: ProviderType
-  dialect: 'postgres' | 'mysql' | 'sqlite'
+  /** The type of provider */
+  readonly type: ProviderType
+  /** The SQL dialect used by this provider */
+  readonly dialect: DatabaseDialect
+  /**
+   * Connect to the database provider
+   * @param config - Provider-specific configuration
+   * @returns A promise that resolves to a database connection
+   */
   connect(config: ProviderConfig): Promise<DatabaseConnection>
-  getMigrationsDriver(): unknown           // TODO: typed per phase 10.1
+  /**
+   * Get the migrations driver for this provider
+   * @returns A migration driver instance
+   */
+  getMigrationsDriver(): DrizzleMigrationDriver
+  /**
+   * Check if this provider supports Row Level Security (RLS)
+   * @returns true if RLS is supported, false otherwise
+   */
   supportsRLS(): boolean
+  /**
+   * Check if this provider supports GraphQL
+   * @returns true if GraphQL is supported (partial for non-Postgres)
+   */
   supportsGraphQL(): boolean
 }
 
-export interface ProviderConfig {
-  type: ProviderType
-  connectionString?: string
-  url?: string
-  authToken?: string
+/**
+ * Type guard to check if a provider config is valid
+ * @param config - The configuration to validate
+ * @returns true if the configuration is valid
+ */
+export function isValidProviderConfig(config: unknown): config is ProviderConfig {
+  return ProviderConfigSchema.safeParse(config).success
 }
 
-// Placeholder — real connection type implemented in Phase 10.1
-export type DatabaseConnection = unknown
+/**
+ * Parse and validate provider configuration
+ * @param config - The configuration to parse
+ * @returns The validated configuration
+ * @throws ZodError if validation fails
+ */
+export function parseProviderConfig(config: unknown): ProviderConfig {
+  return ProviderConfigSchema.parse(config)
+}
+
+/**
+ * Safe parse provider configuration
+ * @param config - The configuration to parse
+ * @returns Result containing either the validated config or error
+ */
+export function safeParseProviderConfig(config: unknown): z.SafeParseReturnType<unknown, ProviderConfig> {
+  return ProviderConfigSchema.safeParse(config)
+}

--- a/templates/base/betterbase.config.ts
+++ b/templates/base/betterbase.config.ts
@@ -1,25 +1,98 @@
-import { z } from 'zod';
+/**
+ * BetterBase Configuration File
+ * 
+ * This file defines the configuration for your BetterBase project.
+ * Update the values below to match your project requirements.
+ * 
+ * Required environment variables:
+ * - DATABASE_URL: Connection string for your database (for neon, postgres, supabase, planetscale)
+ * - TURSO_URL: libSQL connection URL (for turso)
+ * - TURSO_AUTH_TOKEN: Auth token for Turso database (for turso)
+ */
 
-export const BetterBaseConfigSchema = z.object({
-  mode: z.enum(['local', 'neon', 'turso']),
-  database: z.object({
-    local: z.string(),
-    production: z.string().nullable().optional(),
-  }),
-  auth: z.object({
-    enabled: z.boolean(),
-  }),
-});
+import type { BetterBaseConfig } from '@betterbase/core'
 
-export type BetterBaseConfig = z.infer<typeof BetterBaseConfigSchema>;
-
-export const betterbaseConfig: BetterBaseConfig = BetterBaseConfigSchema.parse({
-  mode: 'local',
-  database: {
-    local: 'local.db',
-    production: null,
+/**
+ * BetterBase Project Configuration
+ * 
+ * @example
+ * ```typescript
+ * export default {
+ *   project: {
+ *     name: 'my-betterbase-app',
+ *   },
+ *   provider: {
+ *     type: 'postgres',
+ *     connectionString: process.env.DATABASE_URL,
+ *   },
+ * } satisfies BetterBaseConfig
+ * ```
+ */
+export default {
+  /** Project name - used for identification and metadata */
+  project: {
+    name: 'my-betterbase-app',
   },
-  auth: {
+  
+  /** 
+   * Database provider configuration
+   * 
+   * Supported providers:
+   * - 'postgres': Standard PostgreSQL (uses DATABASE_URL)
+   * - 'neon': Neon serverless PostgreSQL (uses DATABASE_URL)
+   * - 'supabase': Supabase PostgreSQL (uses DATABASE_URL)
+   * - 'planetscale': PlanetScale MySQL (uses DATABASE_URL)
+   * - 'turso': Turso libSQL (uses TURSO_URL and TURSO_AUTH_TOKEN)
+   * - 'managed': BetterBase managed database (uses DATABASE_URL or defaults to local.db)
+   */
+  provider: {
+    /** The database provider type */
+    type: 'postgres' as const,
+    
+    /** 
+     * Database connection string (for postgres, neon, supabase, planetscale)
+     * Format: postgresql://user:pass@host:port/db for PostgreSQL
+     * Format: mysql://user:pass@host:port/db for MySQL/PlanetScale
+     */
+    connectionString: process.env.DATABASE_URL,
+    
+    // Turso-specific (uncomment if using Turso):
+    // url: process.env.TURSO_URL,
+    // authToken: process.env.TURSO_AUTH_TOKEN,
+  },
+  
+  /**
+   * Storage configuration (Phase 14)
+   * Uncomment and configure when implementing file storage
+   */
+  // storage: {
+  //   provider: 's3', // 's3' | 'r2' | 'backblaze' | 'minio' | 'managed'
+  //   bucket: 'my-bucket',
+  //   region: 'us-east-1',
+  //   // For S3-compatible providers:
+  //   // endpoint: 'https://s3.amazonaws.com',
+  // },
+  
+  /**
+   * Webhook configuration (Phase 13)
+   * Uncomment and configure when implementing webhooks
+   */
+  // webhooks: [
+  //   {
+  //     id: 'webhook-1',
+  //     table: 'users',
+  //     events: ['INSERT', 'UPDATE', 'DELETE'],
+  //     url: 'https://example.com/webhook',
+  //     secret: process.env.WEBHOOK_SECRET!,
+  //     enabled: true,
+  //   },
+  // ],
+  
+  /**
+   * GraphQL API configuration
+   * Set enabled: false to disable the GraphQL API
+   */
+  graphql: {
     enabled: true,
   },
-});
+} satisfies BetterBaseConfig


### PR DESCRIPTION
- Add provider adapters for Neon, Turso, PlanetScale, Supabase, Postgres
- Implement ProviderAdapter interface with connect(), getMigrationsDriver(), supportsRLS(), supportsGraphQL()
- Add CLI integration with provider prompts for database selection
- Add Drizzle config generation for each provider type
- Add provider-specific Zod schemas for configuration validation
- Add helper functions: providerSupportsRLS(), getProviderDialect()
- Fix missing @neondatabase/serverless dependency for Neon provider
- Add explicit driver 'pg' for Supabase Drizzle config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded database provider support with streamlined selection during setup.
  * Comprehensive roadmap documentation for upcoming capabilities: Row-Level Security, GraphQL API generation, Webhooks, S3-compatible storage, and Edge Functions.

* **Improvements**
  * Enhanced configuration schema to prepare for future storage and webhook features.
  * Improved initialization flow with better provider-specific setup prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->