### PR TITLE
Fix audit IP fallback and CLI TypeScript regressions

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1339,18 +1339,8 @@ export async function runInitCommand(rawOptions: InitCommandOptions): Promise<vo
 				}
 				// Clean up existing directory
 				try {
-					await Bun.write(projectPath + "/.keep", "");
-					const files = await Bun.file(projectPath).ls();
-					await Promise.all(
-						files.map(async (f) => {
-							const fullPath = path.resolve(projectPath, f.name);
-							await Bun.write(fullPath, "");
-						}),
-					);
-					await Bun.file(projectPath)
-						.delete()
-						.catch(() => {});
-					await Bun.mkdir(projectPath, { recursive: true }).catch(() => {});
+					await rm(projectPath, { recursive: true, force: true });
+					await mkdir(projectPath, { recursive: true });
 				} catch (err) {
 					logger.error(`Failed to clean directory: ${err}`);
 				}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -568,16 +568,19 @@ export function createProgram(): Command {
 				const { runApiKeyLogin } = await import("./commands/login");
 				let password = process.env.ADMIN_PASSWORD;
 				if (!password) {
-					const { default: prompts } = await import("prompts");
-					const result = await prompts({
-						type: "password",
-						name: "password",
-						message: "Admin password:",
-						validate: (p: string) => p.length >= 1,
-					});
+					const { default: inquirer } = await import("inquirer");
+					const result = await inquirer.prompt<{ password: string }>([
+						{
+							type: "password",
+							name: "password",
+							message: "Admin password:",
+							mask: "*",
+							validate: (value: string) => value.length >= 1 || "Password is required",
+						},
+					]);
 					password = result.password;
 				}
-				await runApiKeyLogin({ serverUrl: opts.url, email: opts.email, password });
+				await runApiKeyLogin({ serverUrl: opts.url, email: opts.email, password: password ?? "" });
 			} else {
 				await runLoginCommand({ serverUrl: opts.url });
 			}

--- a/packages/server/src/lib/audit.ts
+++ b/packages/server/src/lib/audit.ts
@@ -73,9 +73,14 @@ export async function writeAuditLog(entry: AuditEntry): Promise<void> {
 
 // Helper: extract IP from Hono context
 export function getClientIp(headers: Headers): string {
-	const fromProxy = headers.get("x-real-ip") ?? headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-	if (fromProxy) return fromProxy;
+	const fromForwardedFor = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+	if (fromForwardedFor) return fromForwardedFor;
+
+	const fromRealIp = headers.get("x-real-ip")?.trim();
+	if (fromRealIp) return fromRealIp;
+
 	const ua = headers.get("user-agent") ?? "";
+	if (!ua) return "unknown";
 	const fp = createHash("sha256").update(ua).digest("hex").slice(0, 16);
 	return `ua:${fp}`;
 }


### PR DESCRIPTION
### Motivation
- Resolve a failing audit test where `getClientIp` produced a UA fingerprint instead of returning `"unknown"` when no IP/user-agent headers are present.  
- Fix TypeScript/typecheck regressions caused by use of Bun-only filesystem APIs and an incompatible dynamic `prompts` import in the CLI `init`/login flows.

### Description
- Updated `getClientIp` in `packages/server/src/lib/audit.ts` to prefer `x-forwarded-for`, then `x-real-ip`, and return `"unknown"` when no proxy or user-agent data exists instead of always generating a UA fingerprint.  
- Replaced unsafe Bun filesystem cleanup logic in `packages/cli/src/commands/init.ts` with `node:fs/promises` `rm(..., { recursive: true, force: true })` and `mkdir(..., { recursive: true })` to avoid Bun-specific APIs that broke typechecking.  
- Replaced dynamic import of `prompts` in the CLI login flow with the existing `inquirer` prompt in `packages/cli/src/index.ts` and ensured the `password` passed to `runApiKeyLogin` is always a string.  
- Small housekeeping: adjusted imports/usage to remove runtime/type errors seen during CI and local typechecks.

### Testing
- Ran `bun test packages/server/test/audit.test.ts` and all audit tests passed.  
- Ran the server test suite with `bun run --cwd packages/server test` and observed no failures for the server package.  
- Ran CLI TypeScript check with `bun run --cwd packages/cli typecheck` (`tsc -p tsconfig.json --noEmit`) and the typecheck passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee99e85c58832f871578ba3abb4d77)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Password input is now masked during CLI login

* **Bug Fixes**
  * Improved client IP detection in audit logs with better fallback handling
  * Enhanced project initialization cleanup for more reliable directory handling
  * Fixed potential undefined values in login flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->